### PR TITLE
Implement persistent pidfile support

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,12 @@
 Revision history for Unix-PID-Tiny
 
+0.92 Thu Apr 18 15:02:03 2019
+    - add support for persistent PID files; allow traversing /proc/$pid/fd
+      to ensure a process indicated by a PID file still holds an open file
+      descriptor for that PID file
+    - add support for checking a PID file's minimum mtime value when testing
+      if the PID file indicates a running PID
+
 0.91 Tue Jul 23 22:46:46 2013
     - rt 86817 - minor fixes
     - rt 86640 - Add pidfile functions from non-tiny version

--- a/META.json
+++ b/META.json
@@ -4,7 +4,7 @@
       "Daniel Muey <http://drmuey.com/cpan_contact.pl>"
    ],
    "dynamic_config" : 1,
-   "generated_by" : "ExtUtils::MakeMaker version 6.64, CPAN::Meta::Converter version 2.120921",
+   "generated_by" : "ExtUtils::MakeMaker version 7.24, CPAN::Meta::Converter version 2.150010",
    "license" : [
       "unknown"
    ],
@@ -32,10 +32,12 @@
       },
       "runtime" : {
          "requires" : {
+            "Test::MockFile" : "0",
             "Test::More" : "0"
          }
       }
    },
    "release_status" : "stable",
-   "version" : "0.91"
+   "version" : "0.92",
+   "x_serialization_backend" : "JSON::PP version 2.27400_02"
 }

--- a/META.yml
+++ b/META.yml
@@ -3,20 +3,22 @@ abstract: 'Subset of Unix::PID functionality with smaller memory footprint'
 author:
   - 'Daniel Muey <http://drmuey.com/cpan_contact.pl>'
 build_requires:
-  ExtUtils::MakeMaker: 0
+  ExtUtils::MakeMaker: '0'
 configure_requires:
-  ExtUtils::MakeMaker: 0
+  ExtUtils::MakeMaker: '0'
 dynamic_config: 1
-generated_by: 'ExtUtils::MakeMaker version 6.64, CPAN::Meta::Converter version 2.120921'
+generated_by: 'ExtUtils::MakeMaker version 7.24, CPAN::Meta::Converter version 2.150010'
 license: unknown
 meta-spec:
   url: http://module-build.sourceforge.net/META-spec-v1.4.html
-  version: 1.4
+  version: '1.4'
 name: Unix-PID-Tiny
 no_index:
   directory:
     - t
     - inc
 requires:
-  Test::More: 0
-version: 0.91
+  Test::MockFile: '0'
+  Test::More: '0'
+version: '0.92'
+x_serialization_backend: 'CPAN::Meta::YAML version 0.018'

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -8,7 +8,8 @@ WriteMakefile(
     ABSTRACT_FROM => 'lib/Unix/PID/Tiny.pm',
     PL_FILES      => {},
     PREREQ_PM     => {
-        'Test::More' => 0,
+        'Test::More'     => 0,
+        'Test::MockFile' => 0
     },
     dist  => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean => { FILES    => 'Unix-PID-Tiny-*' },

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-Unix-PID-Tiny version 0.91
+Unix-PID-Tiny version 0.92
 
 DOCUMENTATION
 
@@ -19,7 +19,7 @@ See DEPENDENCIES section in POD or 'PREREQ_PM' key in Makefile.PL
 
 COPYRIGHT AND LICENCE
 
-Copyright (C) 2008, Daniel Muey
+Copyright (C) 2019, Daniel Muey
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself.


### PR DESCRIPTION
Case CPANEL-24261: Implement support for persistent pidfiles, as a way
to help determine that a long-running process referred to by a PID file
is still active and is still physically the same process holding an open
PID file

Other changes:

* Update version to 0.92

* Add optional argument, $since, to is_pidfile_running() to cause the
  function to not return true if the PID file mtime is less than the
  Unix epoch time specified

* Add usage of Perl warnings