### PR TITLE
Fix build issues

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Unix-PID-Tiny
 
+0.94 Wed Apr 24 16:56:09 2019
+    - declare Test::Warn, File::Slurp, File::Temp dependencies
+    - fix off-by-one test plan error
+
 0.93 Wed Apr 24 14:39:03 2019
     - declare File::Slurp dependency (thanks xantronix!)
     - Clarify the role of `check_proc_open_fds`

--- a/META.yml
+++ b/META.yml
@@ -4,10 +4,14 @@ author:
   - 'Daniel Muey <http://drmuey.com/cpan_contact.pl>'
 build_requires:
   ExtUtils::MakeMaker: '0'
+  Test::MockFile: '0'
+  Test::More: '0'
+  Test::NoWarnings: '0'
+  Test::Warn: '0'
 configure_requires:
   ExtUtils::MakeMaker: '0'
-dynamic_config: 0
-generated_by: 'ExtUtils::MakeMaker version 7.24, CPAN::Meta::Converter version 2.150010, CPAN::Meta::Converter version 2.150001'
+dynamic_config: 1
+generated_by: 'ExtUtils::MakeMaker version 7.24, CPAN::Meta::Converter version 2.150010'
 license: unknown
 meta-spec:
   url: http://module-build.sourceforge.net/META-spec-v1.4.html
@@ -19,7 +23,6 @@ no_index:
     - inc
 requires:
   File::Slurp: '0'
-  Test::MockFile: '0'
-  Test::More: '0'
-version: '0.93'
-x_serialization_backend: 'JSON::PP version 2.27400_02'
+  File::Temp: '0'
+version: '0.94'
+x_serialization_backend: 'CPAN::Meta::YAML version 0.018'

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -8,10 +8,16 @@ WriteMakefile(
     ABSTRACT_FROM => 'lib/Unix/PID/Tiny.pm',
     PL_FILES      => {},
     PREREQ_PM     => {
-        'Test::More'     => 0,
-        'Test::MockFile' => 0,
-        'File::Slurp'    => 0
+        'File::Slurp' => 0,
+        'File::Temp'  => 0
     },
-    dist  => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
-    clean => { FILES    => 'Unix-PID-Tiny-*' },
+    BUILD_REQUIRES => {'ExtUtils::MakeMaker' => 0},
+    TEST_REQUIRES  => {
+        'Test::More'       => 0,
+        'Test::MockFile'   => 0,
+        'Test::NoWarnings' => 0,
+        'Test::Warn'       => 0
+    },
+    dist  => {COMPRESS => 'gzip -9f', SUFFIX => 'gz',},
+    clean => {FILES    => 'Unix-PID-Tiny-*'},
 );

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-Unix-PID-Tiny version 0.93
+Unix-PID-Tiny version 0.94
 
 DOCUMENTATION
 

--- a/lib/Unix/PID/Tiny.pm
+++ b/lib/Unix/PID/Tiny.pm
@@ -3,7 +3,7 @@ package Unix::PID::Tiny;
 use strict;
 use warnings;
 
-our $VERSION = '0.93';
+our $VERSION = '0.94';
 
 sub new {
     my ( $self, $args_hr ) = @_;
@@ -298,7 +298,7 @@ footprint
 
 =head1 VERSION
 
-This document describes Unix::PID::Tiny version 0.93.
+This document describes Unix::PID::Tiny version 0.94.
 
 =head1 SYNOPSIS
 

--- a/t/01.methods.t
+++ b/t/01.methods.t
@@ -6,7 +6,7 @@ use warnings;
 use File::Slurp;
 use File::Temp;
 
-use Test::More tests => 86 + 1;    # +1 is for NoWarnings
+use Test::More tests => 85 + 1;    # +1 is for NoWarnings
 use Test::NoWarnings;
 
 use Test::Warn;


### PR DESCRIPTION
Fix build issues due to missing dependency declarations, as well as an
invalid, off-by-one test plan

Other changes:

    * Bump version to 0.94