### PR TITLE
Don't use buffered I/O to write PID to file

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Unix-PID-Tiny
 
+0.95 Tue Apr 30 13:48:03 2019
+    - use syswrite() rather than print() to immediately write PID to file
+
 0.94 Wed Apr 24 16:56:09 2019
     - declare Test::Warn, File::Slurp, File::Temp dependencies
     - fix off-by-one test plan error

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-Unix-PID-Tiny version 0.94
+Unix-PID-Tiny version 0.95
 
 DOCUMENTATION
 

--- a/lib/Unix/PID/Tiny.pm
+++ b/lib/Unix/PID/Tiny.pm
@@ -3,7 +3,7 @@ package Unix::PID::Tiny;
 use strict;
 use warnings;
 
-our $VERSION = '0.94';
+our $VERSION = '0.95';
 
 sub new {
     my ( $self, $args_hr ) = @_;
@@ -263,7 +263,7 @@ sub pid_file_no_unlink {
         goto EXISTS;
     }
 
-    print {$pid_fh} int( abs($newpid) );
+    syswrite( $pid_fh, int( abs($newpid) ) );
 
     if ( $self->{'keep_open'} ) {
         push @{ $self->{'open_handles'} }, $pid_fh;
@@ -298,7 +298,7 @@ footprint
 
 =head1 VERSION
 
-This document describes Unix::PID::Tiny version 0.94.
+This document describes Unix::PID::Tiny version 0.95.
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
Don't use buffered I/O to write PID to file

Other changes:

* Bump version to 0.95