### PR TITLE
Ensure atomic PID file writes

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 Revision history for Unix-PID-Tiny
 
+0.96 Tue Apr 30 21:48:50 2019
+    - write PID file to temporary file, then rename it so that PID files can
+      be accessed atomically, avoiding race conditions where PID files may be
+      empty when first read
+
 0.95 Tue Apr 30 13:48:03 2019
     - use syswrite() rather than print() to immediately write PID to file
 

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-Unix-PID-Tiny version 0.95
+Unix-PID-Tiny version 0.96
 
 DOCUMENTATION
 

--- a/lib/Unix/PID/Tiny.pm
+++ b/lib/Unix/PID/Tiny.pm
@@ -3,7 +3,7 @@ package Unix::PID::Tiny;
 use strict;
 use warnings;
 
-our $VERSION = '0.95';
+our $VERSION = '0.96';
 
 sub new {
     my ( $self, $args_hr ) = @_;
@@ -250,8 +250,10 @@ sub pid_file_no_unlink {
         unlink $pid_file;                                  # must be a stale PID file, so try to remove it for sysopen()
     }
 
+    my $tmp_pid_file = "$pid_file.$newpid";
+
     # write only if it does not exist:
-    my $pid_fh = _sysopen($pid_file);
+    my $pid_fh = _sysopen($tmp_pid_file);
     if ( !$pid_fh ) {
         return 0 if $passes >= $retry_conf->[0];
         if ( ref( $retry_conf->[$passes] ) eq 'CODE' ) {
@@ -264,6 +266,8 @@ sub pid_file_no_unlink {
     }
 
     syswrite( $pid_fh, int( abs($newpid) ) );
+
+    rename( $tmp_pid_file, $pid_file );
 
     if ( $self->{'keep_open'} ) {
         push @{ $self->{'open_handles'} }, $pid_fh;
@@ -298,7 +302,7 @@ footprint
 
 =head1 VERSION
 
-This document describes Unix::PID::Tiny version 0.95.
+This document describes Unix::PID::Tiny version 0.96.
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
Ensure atomic PID file writes by writing PID to a temporary file named
for the PID, then renaming said file to the intended original filename

Other changes:

* Bump version to 0.96