### PR TITLE
Fix bug in scanning /proc/$pid/fd for open pidfile

### DIFF
--- a/lib/Unix/PID/Tiny.pm
+++ b/lib/Unix/PID/Tiny.pm
@@ -148,7 +148,7 @@ sub is_pidfile_running {
 
         opendir my $dh, $dir or return;
 
-        while ( my $dirent = readdir $dh ) {
+        while ( defined ( my $dirent = readdir $dh ) ) {
             next if $dirent eq '.' || $dirent eq '..';
 
             my $path = "$dir/$dirent";
@@ -237,7 +237,7 @@ sub pid_file_no_unlink {
 
   EXISTS:
     $passes++;
-    if ( -e $pid_file ) {
+    if ( -e $pid_file && !$self->{'keep_open'} ) {
         my $curpid = $self->get_pid_from_pidfile($pid_file);
 
         # TODO: narrow even more the race condition where $curpid stops running and a new PID is put in


### PR DESCRIPTION
Fix bug in scanning /proc/$pid/fd for open pidfile caused by
encountering file descriptor 0, which in Perl evaluates to a non-truthy
value